### PR TITLE
Upgrade dependency to 0.6.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_math_fork: ^0.3.3
+  flutter_math_fork: ^0.6.0
 dev_dependencies:
   lint: ^1.5.2


### PR DESCRIPTION
simpleclub-extended/flutter_math_fork#7 was preventing me from using your project.

Forcing a dependency override to ^0.6.0 of flutter_math_fork solved the issue, albeit being a clunky workaround.

This PR, in effect, changes the version requirement from `0.3.3 ..< 0.4.0` to `0.6.0 ..< 0.7.0`